### PR TITLE
Update fiberplane packages to use traces locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "db:seed": "tsx seed.ts",
     "db:setup": "npm run db:touch && npm run db:generate && npm run db:migrate && npm run db:seed",
     "db:studio": "drizzle-kit studio",
-    "fiberplane": "npx @fiberplane/studio@latest"
+    "fiberplane": "npx @fiberplane/studio@canary"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.33.1",
-    "@fiberplane/embedded": "^0.0.24",
+    "@fiberplane/embedded": "^0.0.26",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.36.4",
     "hono": "^4.6.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.33.1
         version: 0.33.1
       '@fiberplane/embedded':
-        specifier: ^0.0.24
-        version: 0.0.24(hono@4.6.17)
+        specifier: ^0.0.26
+        version: 0.0.26(hono@4.6.17)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.7
@@ -666,8 +666,8 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@fiberplane/embedded@0.0.24':
-    resolution: {integrity: sha512-AKOTll85Cq3PZxO/SSCbZ+BFm9RQOYkhv23ro4W6zxNKaHOpTAJ+gH+6rWT3E63oyBa9S2KeoV0d4CBVhBAOsQ==}
+  '@fiberplane/embedded@0.0.26':
+    resolution: {integrity: sha512-uieU6fj2Fn5xqeDPCxgo/ViUC4ico6k84ToCtavkThXmS8pxzs8sw9jg+ewI+ymkKPbOVKnajvKJef1yE7EP3g==}
     peerDependencies:
       hono: ^4.0
 
@@ -1670,7 +1670,7 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@fiberplane/embedded@0.0.24(hono@4.6.17)':
+  '@fiberplane/embedded@0.0.26(hono@4.6.17)':
     dependencies:
       hono: 4.6.17
       openapi-types: 12.1.3


### PR DESCRIPTION
`pnpm fiberplane` launches a canary version of studio that can act as a sidecar to ingest traces 

`pnpm dev` will now mount an updated embedded package with traces UI (and workflows) 