### PR TITLE
Update embedded to support remote traces

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.33.1",
-    "@fiberplane/embedded": "^0.0.27",
+    "@fiberplane/embedded": "0.0.28-alpha.3",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.36.4",
     "hono": "^4.6.7"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.33.1",
-    "@fiberplane/embedded": "0.0.28-alpha.3",
+    "@fiberplane/embedded": "0.0.28",
     "@fiberplane/hono-otel": "0.6.2",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.36.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.33.1",
-    "@fiberplane/embedded": "^0.0.26",
+    "@fiberplane/embedded": "^0.0.27",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.36.4",
     "hono": "^4.6.7"

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.33.1",
     "@fiberplane/embedded": "0.0.28-alpha.3",
+    "@fiberplane/hono-otel": "0.6.2",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.36.4",
     "hono": "^4.6.7"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241205.0",
-    "@fiberplane/hono-otel": "^0.6.2",
     "@libsql/client": "^0.14.0",
     "drizzle-kit": "^0.28.1",
     "drizzle-seed": "^0.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.33.1
         version: 0.33.1
       '@fiberplane/embedded':
-        specifier: ^0.0.26
-        version: 0.0.26(hono@4.6.17)
+        specifier: ^0.0.27
+        version: 0.0.27(hono@4.6.17)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.7
@@ -666,8 +666,8 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@fiberplane/embedded@0.0.26':
-    resolution: {integrity: sha512-uieU6fj2Fn5xqeDPCxgo/ViUC4ico6k84ToCtavkThXmS8pxzs8sw9jg+ewI+ymkKPbOVKnajvKJef1yE7EP3g==}
+  '@fiberplane/embedded@0.0.27':
+    resolution: {integrity: sha512-KLvUSv+Lz0MpHBqvSfJuWtuv/e+ezMjTXdVS0bBdlRpR/PdeDE3iXMqz3EyD9kGzCeBgKzsJapApkbC85zkvdw==}
     peerDependencies:
       hono: ^4.0
 
@@ -1670,7 +1670,7 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@fiberplane/embedded@0.0.26(hono@4.6.17)':
+  '@fiberplane/embedded@0.0.27(hono@4.6.17)':
     dependencies:
       hono: 4.6.17
       openapi-types: 12.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.33.1
         version: 0.33.1
       '@fiberplane/embedded':
-        specifier: 0.0.28-alpha.3
-        version: 0.0.28-alpha.3(hono@4.6.17)
+        specifier: 0.0.28
+        version: 0.0.28(hono@4.6.17)
       '@fiberplane/hono-otel':
         specifier: 0.6.2
         version: 0.6.2
@@ -666,8 +666,8 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@fiberplane/embedded@0.0.28-alpha.3':
-    resolution: {integrity: sha512-rGyZsC+vUmjtfhLAcV0tU55acAPuQBIzKvolJliRRM3yZkIC+3ZKwaTHG9GD30uHuQCMewWW+HFmyG3yZbhZsw==}
+  '@fiberplane/embedded@0.0.28':
+    resolution: {integrity: sha512-gyvdYChtz4uu3LnWRhrqEtZYlsSfpsfFJiAYiSQbRN42zClSTim6LYt7YESPDzvBegncYY6RV4hun9GTP0k1kA==}
     peerDependencies:
       hono: ^4.0
 
@@ -1670,7 +1670,7 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@fiberplane/embedded@0.0.28-alpha.3(hono@4.6.17)':
+  '@fiberplane/embedded@0.0.28(hono@4.6.17)':
     dependencies:
       hono: 4.6.17
       openapi-types: 12.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.33.1
         version: 0.33.1
       '@fiberplane/embedded':
-        specifier: ^0.0.27
-        version: 0.0.27(hono@4.6.17)
+        specifier: 0.0.28-alpha.3
+        version: 0.0.28-alpha.3(hono@4.6.17)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.7
@@ -666,8 +666,8 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@fiberplane/embedded@0.0.27':
-    resolution: {integrity: sha512-KLvUSv+Lz0MpHBqvSfJuWtuv/e+ezMjTXdVS0bBdlRpR/PdeDE3iXMqz3EyD9kGzCeBgKzsJapApkbC85zkvdw==}
+  '@fiberplane/embedded@0.0.28-alpha.3':
+    resolution: {integrity: sha512-rGyZsC+vUmjtfhLAcV0tU55acAPuQBIzKvolJliRRM3yZkIC+3ZKwaTHG9GD30uHuQCMewWW+HFmyG3yZbhZsw==}
     peerDependencies:
       hono: ^4.0
 
@@ -1670,7 +1670,7 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@fiberplane/embedded@0.0.27(hono@4.6.17)':
+  '@fiberplane/embedded@0.0.28-alpha.3(hono@4.6.17)':
     dependencies:
       hono: 4.6.17
       openapi-types: 12.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@fiberplane/embedded':
         specifier: 0.0.28-alpha.3
         version: 0.0.28-alpha.3(hono@4.6.17)
+      '@fiberplane/hono-otel':
+        specifier: 0.6.2
+        version: 0.6.2
       dotenv:
         specifier: ^16.4.5
         version: 16.4.7
@@ -27,9 +30,6 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20250109.0
-      '@fiberplane/hono-otel':
-        specifier: ^0.6.2
-        version: 0.6.2
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0

--- a/src/apiSpec.ts
+++ b/src/apiSpec.ts
@@ -5,12 +5,12 @@ export const apiSpec = {
     description: "API for managing a seasonal fashion catalog",
     version: "1.0.0"
   },
-  servers: [
-    {
-      url: "http://localhost:8787",
-      description: "Local server"
-    }
-  ],
+  // servers: [
+  //   {
+  //     url: "http://localhost:8787",
+  //     description: "Local server"
+  //   }
+  // ],
   paths: {
     "/api/fashion-items": {
       get: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,6 @@ app.get("/", async (c) => {
   return c.text("*Fashionable HONC* ☁️🪿👗");
 });
 
-app.get("/favicon.ico", async (c) => {
-  return c.text("Honc from above! ☁️🪿");
-});
-
 app.get("/openapi.json", (c) => {
   return c.json(apiSpec);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ app.get("/openapi.json", (c) => {
 app.use(
   "/fp/*",
   createMiddleware({
-    openapi: { content: JSON.stringify(apiSpec) },
+    openapi: { url: "/openapi.json" },
     apiKey: "",
   }),
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,7 @@ import * as schema from "./db/schema";
 import { createMiddleware } from "@fiberplane/embedded";
 import apiSpec from "./apiSpec";
 import Anthropic from "@anthropic-ai/sdk";
-import { env } from "hono/adapter";
-import { GeneratedFashionItem, validateGeneratedItem } from "./types";
+import { type GeneratedFashionItem, validateGeneratedItem } from "./types";
 
 type Bindings = {
   DB: D1Database;
@@ -22,7 +21,7 @@ const app = new Hono<{ Bindings: Bindings }>();
 
 app.use("*", cors());
 
-app.get("/", (c) => {
+app.get("/", async (c) => {
   return c.text("Honc from above! ☁️🪿");
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { createMiddleware } from "@fiberplane/embedded";
 import apiSpec from "./apiSpec";
 import Anthropic from "@anthropic-ai/sdk";
 import { type GeneratedFashionItem, validateGeneratedItem } from "./types";
+import { serveEmojiFavicon } from "./middleware";
 
 type Bindings = {
   DB: D1Database;
@@ -21,7 +22,13 @@ const app = new Hono<{ Bindings: Bindings }>();
 
 app.use("*", cors());
 
+app.use("*", serveEmojiFavicon("👗"));
+
 app.get("/", async (c) => {
+  return c.text("*Fashionable HONC* ☁️🪿👗");
+});
+
+app.get("/favicon.ico", async (c) => {
   return c.text("Honc from above! ☁️🪿");
 });
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,16 @@
+import type { MiddlewareHandler } from "hono";
+
+/**
+ * Serve an emoji as a favicon.
+ * Ripped from Stoker:
+ * > https://github.com/w3cj/stoker/blob/main/src/middlewares/serve-emoji-favicon.ts
+ */
+export const serveEmojiFavicon = (emoji: string): MiddlewareHandler => {
+  return async (c, next) => {
+    if (c.req.path === "/favicon.ico") {
+      c.header("Content-Type", "image/svg+xml");
+      return c.body(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" x="-0.1em" font-size="90">${emoji}</text></svg>`);
+    }
+    return next();
+  };
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ compatibility_flags = [ "nodejs_compat" ]
 [[d1_databases]]
 binding = "DB"
 database_name = "fashion"
-database_id = "local-fashion"
+database_id = "3d029485-d2b7-4ac4-a70b-a7522a9abf05"
 migrations_dir = "drizzle/migrations"
 
 # [vars]


### PR DESCRIPTION
- Update embedded to version `0.0.28` which supports latest playground + proxying requests for tracing data (from the UI) to a production ingestion engine

- Move `hono-otel` to prod deps

- Update `wrangler.toml` to point to the correct D1 database id

- Comment out the default server of :8787 in the apiSpec

- Use path instead of raw spec when passing openapi spec details to fiberplane embedded

- Add a favicon